### PR TITLE
Fix #34 and address #29. A couple of other very minor tweaks

### DIFF
--- a/src/pybites_search/all_content.py
+++ b/src/pybites_search/all_content.py
@@ -23,32 +23,31 @@ class AllSearch(PybitesSearch):
 
     def show_matches(self, content: list[ContentPiece]) -> None:
         """Show search results in a nice table"""
-        if content:
-            channel = None
-            table = Table(
-                "Title",
-                "Url",
-                title=self.title,
-                header_style=STYLE_HEADER,
-                show_header=False,
-                title_style=STYLE_HEADER,
-            )
-            for row in content:
-                if row.channel != channel:
-                    if channel:
-                        table.add_section()
-                    table.add_row(
-                        row.channel,
-                        "Url",
-                        style=STYLE_HEADER,
-                        end_section=True,
-                    )
-                    channel = row.channel
-                table.add_row(row.title, row.url)
-
-            console.print(table)
-        else:
+        if not content:
             error_console.print("No results found")
+            return
+
+        channel = None
+        table = Table(
+            "Title",
+            "Url",
+            title=self.title,
+            show_header=False,
+            title_style=STYLE_HEADER,
+        )
+        for row in content:
+            if row.channel != channel:
+                table.add_section()
+                table.add_row(
+                    row.channel,
+                    "Url",
+                    style=STYLE_HEADER,
+                    end_section=True,
+                )
+                channel = row.channel
+            table.add_row(row.title, row.url)
+
+        console.print(table)
 
 
 if __name__ == "__main__":

--- a/src/pybites_search/cli.py
+++ b/src/pybites_search/cli.py
@@ -10,43 +10,36 @@ from .youtube import YouTubeSearch
 app = typer.Typer()
 
 
-@app.command()
-def article(search: str):
-    searcher = ArticleSearch()
+def search_content(searcher, search):
     results = searcher.match_content(search)
     searcher.show_matches(results)
+
+
+@app.command()
+def article(search: str):
+    search_content(ArticleSearch(), search)
 
 
 @app.command()
 def bite(search: str):
-    searcher = BiteSearch()
-    results = searcher.match_content(search)
-    searcher.show_matches(results)
+    search_content(BiteSearch(), search)
 
 
 @app.command()
 def podcast(search: str):
-    searcher = PodcastSearch()
-    results = searcher.match_content(search)
-    searcher.show_matches(results)
+    search_content(PodcastSearch(), search)
 
 
 @app.command()
 def tip(search: str):
-    searcher = TipSearch()
-    results = searcher.match_content(search)
-    searcher.show_matches(results)
+    search_content(TipSearch(), search)
 
 
 @app.command()
 def video(search: str):
-    searcher = YouTubeSearch()
-    results = searcher.match_content(search)
-    searcher.show_matches(results)
+    search_content(YouTubeSearch(), search)
 
 
 @app.command()
 def all(search: str):
-    searcher = AllSearch()
-    results = searcher.match_content(search)
-    searcher.show_matches(results)
+    search_content(AllSearch(), search)

--- a/tests/test_all_content.py
+++ b/tests/test_all_content.py
@@ -87,19 +87,25 @@ def test_all_search_show_matches(capfd):
             channel="Article",
         ),
         ContentPiece(
-            title="FastAPI: A Modern Web Framework to Build APIs with Python 3.7+",
+            title="FastAPI: A Modern Web Framework",
             url="https://example.com/fastapi2",
             channel="Article",
         ),
         ContentPiece(
-            title="Python Bytes Podcast #235: FastAPI, security, and testing",
+            title="Python Bytes Podcast #235: FastAPI",
             url="https://example.com/fastapi3",
             channel="Podcast",
         ),
     ]
+
+    expected_output_text = []
+    for content_piece in content:
+        expected_output_text.append(content_piece.title)
+        expected_output_text.append(content_piece.url)
+
     with patch("pybites_search.base.console"):
         searcher = AllSearch()
         searcher.show_matches(content)
-        captured = capfd.readouterr().out
-        expected = "                              Pybites All Content                               \n┌───────────────────────────────────────────────┬──────────────────────────────┐\n│ Article                                       │ Url                          │\n├───────────────────────────────────────────────┼──────────────────────────────┤\n│ FastAPI Tutorial                              │ https://example.com/fastapi  │\n│ FastAPI: A Modern Web Framework to Build APIs │ https://example.com/fastapi2 │\n│ with Python 3.7+                              │                              │\n├───────────────────────────────────────────────┼──────────────────────────────┤\n│ Podcast                                       │ Url                          │\n├───────────────────────────────────────────────┼──────────────────────────────┤\n│ Python Bytes Podcast #235: FastAPI, security, │ https://example.com/fastapi3 │\n│ and testing                                   │                              │\n└───────────────────────────────────────────────┴──────────────────────────────┘\n"
-        assert captured == expected
+        captured = capfd.readouterr()[0]
+        for text in expected_output_text:
+            assert text in captured

--- a/tests/test_tip.py
+++ b/tests/test_tip.py
@@ -67,7 +67,8 @@ def test_show_tip_matches(mock_data, capfd):
 
         searcher.show_matches(results)
         output = capfd.readouterr()[0]
-        assert all(text in output for text in expected_output_text)
+        for text in expected_output_text:
+            assert text in output
 
         results = searcher.match_content("bogus")
         searcher.show_matches(results)


### PR DESCRIPTION
Fix `test_all_search_show_matches` by shortening and only searching for Title and URL in the captured output.

Flatten and simplify `AllSearch.show_matches`

Modify tests in `test_tip.py` and `test_all_content.py` so that an `assert` is run for each text search to give better PyTest output on fail

Add wrapper `search_content` in `cli.py` to reduce repeated code.